### PR TITLE
feat(storybook): add live reload for core changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21787,6 +21787,71 @@
         }
       }
     },
+    "node_modules/vite-plugin-live-reload": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-live-reload/-/vite-plugin-live-reload-3.0.4.tgz",
+      "integrity": "sha512-hhFuCoCnrH3mJCsiRjpbSFPI2EoUOoLQ3evxCXhzptLXRrsC5kFcByk/gUyngsn9LvDuIOn85ZnejqCApM51gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "picocolors": "^1.1.1"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/vite-plugin-live-reload/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-plugin-live-reload/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vite-plugin-live-reload/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -22766,7 +22831,8 @@
         "concurrently": "^9.1.2",
         "http-server": "^14.1.1",
         "storybook": "^8.5.8",
-        "vite": "^6.1.1"
+        "vite": "^6.1.1",
+        "vite-plugin-live-reload": "^3.0.4"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.34.8"

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -35,7 +35,12 @@ const config: StorybookConfig = {
     config.base = BASE_PATH || config.base
 
     const { mergeConfig } = await import('vite');
+    const { liveReload } = await import('vite-plugin-live-reload');
+
     return mergeConfig(config, {
+      plugins: [
+        liveReload('../core/www/build/stencil-storybook-boilerplate.esm.js'),
+      ],
       build: {
         chunkSizeWarningLimit: 1000,
         rollupOptions: {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -28,7 +28,8 @@
     "concurrently": "^9.1.2",
     "http-server": "^14.1.1",
     "storybook": "^8.5.8",
-    "vite": "^6.1.1"
+    "vite": "^6.1.1",
+    "vite-plugin-live-reload": "^3.0.4"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.34.8"


### PR DESCRIPTION
## Description
This PR aims to improve the developer experience when using Storybook by reloading when the build output of `packages/core` changes.
This is achieved by integrating a Vite plugin ([vite-plugin-live-reload](https://github.com/arnoson/vite-plugin-live-reload))

## Motivation and Context
I started using this boilerplate for a project, and I have enjoyed the setup. Thank you!

While doing so, I identified an opportunity to improve the workflow with Storybook. I noticed that 
 changes in the core package do not trigger a reload. 
I tried configuring Vite's HMR & server to detect changes with the core package, but without much success.

I found an alternative approach with a plugin. It worked when configured to watch the esm module path that's added in the preview header.

While this is not as ideal as HMR, I found that works pretty well in Storybook as it only reloads the preview iframes. The top-level page for the Storybook is not reloaded, and the state of the UI is mostly retained.

## Demo Video

https://github.com/user-attachments/assets/a2f1c0a5-6ecc-47ab-925f-4c96889b7259



